### PR TITLE
Expand Snowflake syntax coverage

### DIFF
--- a/docs/unsupported_snowflake_syntax.md
+++ b/docs/unsupported_snowflake_syntax.md
@@ -3,27 +3,12 @@
 The SQL Analyzer currently parses a large portion of Snowflake SQL, but several syntax areas remain unsupported or only partially implemented. This document summarizes the main gaps.
 
 ## Core SQL Features
-- `QUALIFY` clause
-- `SAMPLE`/`TABLESAMPLE`
-- `PIVOT` and `UNPIVOT`
-- Window frame options like `ROWS BETWEEN` and `RANGE BETWEEN`
-- Advanced built-in functions such as `DATEADD`, `DATEDIFF`, `RESULT_SCAN`, and `LAST_QUERY_ID`
+- Advanced built-in functions such as `DATEADD` and `DATEDIFF`
 
 ## DDL and Data Types
-- Complete support for Snowflake data types (e.g., `VARIANT`, `OBJECT`, `ARRAY`, `TIME`, `GEOGRAPHY`)
 - `ALTER TABLE` variants like `PIVOT`/`UNPIVOT` and advanced clustering options
-- Expanded `GRANT`/`REVOKE` privileges and role management features
-- `SHOW`/`DESCRIBE` for all Snowflake object kinds
-
-## Procedural and Scripting Constructs
-- `IF`, `ELSE`, and `CASE` blocks inside scripting
-- Looping constructs (`LOOP`, `WHILE`, `FOR`)
-- Exception handling (`TRY`/`CATCH`)
-- Multi-statement blocks with variable scoping and `RETURN`
 
 ## Semi-Structured Data and Table Functions
-- Full `FLATTEN` support including `PATH`, `OUTER`, and `RECURSIVE` parameters
-- Additional table functions like `OBJECT_KEYS` and `ARRAY_SIZE`
 - User-defined table functions (UDTFs)
 
 ## Ecosystem and Advanced Services

--- a/sql_analyzer/grammar/snowflake.lark
+++ b/sql_analyzer/grammar/snowflake.lark
@@ -74,13 +74,19 @@ INTEGER: "INTEGER"i
 VARCHAR: "VARCHAR"i
 DOUBLE: "DOUBLE"i
 FLOAT: "FLOAT"i
+TIME: "TIME"i
 DATE: "DATE"i
 TIMESTAMP: "TIMESTAMP"i
+TIMESTAMP_NTZ: "TIMESTAMP_NTZ"i
+TIMESTAMP_LTZ: "TIMESTAMP_LTZ"i
+TIMESTAMP_TZ: "TIMESTAMP_TZ"i
+TZ: "TZ"i
 VARIANT: "VARIANT"i
 RESULTSET: "RESULTSET"i
 OBJECT: "OBJECT"i
 ARRAY: "ARRAY"i
 MAP: "MAP"i
+GEOGRAPHY: "GEOGRAPHY"i
 
 // DDL Commands
 CREATE: "CREATE"i
@@ -214,6 +220,10 @@ STREAMS: "STREAMS"i
 STAGES: "STAGES"i
 DATABASES: "DATABASES"i
 SCHEMAS: "SCHEMAS"i
+SEQUENCES: "SEQUENCES"i
+FUNCTIONS: "FUNCTIONS"i
+PROCEDURES: "PROCEDURES"i
+FORMATS: "FORMATS"i
 ELSE: "ELSE"i
 END: "END"i
 ANY: "ANY"i
@@ -242,6 +252,7 @@ ENDPOINTS: "ENDPOINTS"i
 PUBLIC: "PUBLIC"i
 READINESS_PROBE: "READINESS_PROBE"i
 PATH: "PATH"i
+RECURSIVE: "RECURSIVE"i
 PORT: "PORT"i
 ENV: "ENV"i
 SERVER_PORT: "SERVER_PORT"i
@@ -792,12 +803,17 @@ data_type: IDENTIFIER (LPAREN number ( COMMA number)? RPAREN)? null_constraint?
          | FLOAT null_constraint?
          | BOOLEAN null_constraint?
          | DATE null_constraint?
-         | TIMESTAMP null_constraint?
+         | TIME (LPAREN number RPAREN)? TZ? null_constraint?
+         | TIMESTAMP (LPAREN number RPAREN)? null_constraint?
+         | TIMESTAMP_NTZ (LPAREN number RPAREN)? null_constraint?
+         | TIMESTAMP_LTZ (LPAREN number RPAREN)? null_constraint?
+         | TIMESTAMP_TZ (LPAREN number RPAREN)? null_constraint?
          | VARIANT null_constraint?
-         | RESULTSET null_constraint?
          | OBJECT (LPAREN object_field_def (COMMA object_field_def)* RPAREN)? null_constraint?
          | ARRAY (LPAREN data_type RPAREN)? null_constraint?
          | MAP (LPAREN data_type COMMA data_type RPAREN)? null_constraint?
+         | GEOGRAPHY null_constraint?
+         | RESULTSET null_constraint?
          | TABLE LPAREN column_def ( COMMA column_def)* RPAREN
 
 // Null constraint for data types
@@ -931,6 +947,7 @@ proc_statement: if_stmt
               | case_stmt
               | while_stmt
               | for_stmt
+              | loop_stmt
               | return_stmt
               | raise_stmt
               | assignment_stmt
@@ -943,6 +960,8 @@ case_stmt: CASE (expr)? (WHEN expr THEN statement_list)+ (ELSE statement_list)? 
 while_stmt: WHILE expr DO statement_list END WHILE
 
 for_stmt: FOR IDENTIFIER IN expr DO statement_list END FOR
+
+loop_stmt: LOOP statement_list END LOOP
 
 return_stmt: RETURN (TABLE LPAREN expr RPAREN | expr)?
 
@@ -1074,8 +1093,7 @@ alter_stream_stmt: ALTER STREAM qualified_name SET stream_set_clause
 alter_pipe_stmt: ALTER PIPE qualified_name (REFRESH | SET pipe_param ( COMMA pipe_param )*)
 
 // DROP statements
-drop_stmt: DROP object_type (IF EXISTS)? qualified_name
-        | drop_share_stmt
+drop_stmt: drop_share_stmt
         | drop_integration_stmt
         | drop_external_table_stmt
         | drop_materialized_view_stmt
@@ -1083,9 +1101,10 @@ drop_stmt: DROP object_type (IF EXISTS)? qualified_name
         | drop_network_policy_stmt
         | drop_join_policy_stmt
         | drop_iceberg_table_stmt
+        | DROP object_type (IF EXISTS)? qualified_name
         | DROP (IF EXISTS)? ROW ACCESS POLICY qualified_name
         | DROP (IF EXISTS)? MASKING POLICY qualified_name
-object_type: TABLE | VIEW | WAREHOUSE | TASK | STREAM | PIPE | STAGE | DATABASE | SCHEMA | PROCEDURE | FUNCTION | SEQUENCE | SHARE | INTEGRATION | STORAGE INTEGRATION | NOTIFICATION INTEGRATION | EXTERNAL TABLE | MATERIALIZED VIEW | EXTERNAL FUNCTION | JOIN POLICY | LISTING | STREAMLIT | DYNAMIC TABLE | HYBRID TABLE | DATASET | MODEL | SNAPSHOT | EXTERNAL VOLUME | CATALOG INTEGRATION | COMPUTE POOL | CONNECTION | APPLICATION PACKAGE | PASSWORD POLICY | NETWORK RULE | SECRET | SERVICE | ROW ACCESS POLICY | MASKING POLICY
+object_type: TABLE | VIEW | WAREHOUSE | TASK | STREAM | PIPE | STAGE | DATABASE | SCHEMA | PROCEDURE | FUNCTION | SEQUENCE | SHARE | INTEGRATION | STORAGE INTEGRATION | NOTIFICATION INTEGRATION | EXTERNAL TABLE | MATERIALIZED VIEW | EXTERNAL FUNCTION | JOIN POLICY | LISTING | STREAMLIT | DYNAMIC TABLE | HYBRID TABLE | DATASET | MODEL | SNAPSHOT | EXTERNAL VOLUME | CATALOG INTEGRATION | COMPUTE POOL | CONNECTION | APPLICATION PACKAGE | PASSWORD POLICY | NETWORK RULE | NETWORK POLICY | SECRET | SERVICE | ROW ACCESS POLICY | MASKING POLICY | FILE FORMAT
 
 // TRUNCATE statement
 truncate_stmt: TRUNCATE TABLE qualified_name
@@ -1098,6 +1117,7 @@ show_stmt: SHOW object_types like_clause? scope_clause?
          | SHOW ENDPOINTS IN SERVICE qualified_name
 object_types: TABLES | VIEWS | WAREHOUSES | TASKS | STREAMS | STAGES | DATABASES | SCHEMAS
             | SHARES | INTEGRATIONS | REPLICATIONS | EXTERNAL TABLES | MATERIALIZED VIEWS | USERS | ROLES | PARAMETERS | JOIN POLICIES | FAILOVER GROUPS | LISTINGS | RELEASES | STREAMLITS | DYNAMIC_TABLES | DYNAMIC TABLES | HYBRID_TABLES | HYBRID TABLES | DATASETS | MODELS | SNAPSHOTS | EXTERNAL_VOLUMES | EXTERNAL VOLUMES | COMPUTE POOLS | CONNECTIONS | APPLICATION PACKAGES | PASSWORD POLICIES | ROW ACCESS POLICIES | MASKING POLICIES | NETWORK RULES | SECRETS | ICEBERG TABLES | RELEASE_DIRECTIVES | IMAGE REPOSITORIES | SERVICES | VERSIONS
+            | NETWORK POLICIES | SEQUENCES | FUNCTIONS | PROCEDURES | FILE FORMATS | STORAGE INTEGRATIONS | NOTIFICATION INTEGRATIONS
 like_clause: LIKE SINGLE_QUOTED_STRING
 scope_clause: IN (DATABASE | SCHEMA) qualified_name
 
@@ -1153,6 +1173,8 @@ privilege: CREATE JOIN POLICY
          | INSERT
          | UPDATE
          | DELETE
+         | REFERENCES
+         | TRIGGER
          | USAGE
          | CREATE
          | APPLY
@@ -1255,6 +1277,7 @@ array_element_list: expr (COMMA expr)*
 
 named_parameter: COLON IDENTIFIER
 
+TRIGGER: "TRIGGER"i
 TRIGGERS: "TRIGGERS"i
 PERCENT: "PERCENT"i
 DO: "DO"i

--- a/tests/grammar/test_snowflake_constructs.py
+++ b/tests/grammar/test_snowflake_constructs.py
@@ -299,4 +299,110 @@ class TestSnowflakeProcedureWithReturnTable:
           END;
         """
         tree = parse_sql(sql)
-        assert tree is not None 
+        assert tree is not None
+
+
+class TestSnowflakeDataTypes:
+    """Tests for extended Snowflake data types"""
+
+    def test_complex_data_types(self):
+        sql = """
+        CREATE TABLE t (
+            v VARIANT,
+            o OBJECT,
+            a ARRAY(VARCHAR),
+            tm TIME(3) TZ,
+            d DATE,
+            nt TIMESTAMP_NTZ(9),
+            lt TIMESTAMP_LTZ,
+            tz TIMESTAMP_TZ(6),
+            g GEOGRAPHY
+        );
+        """
+        tree = parse_sql(sql)
+        assert tree is not None
+
+
+class TestSnowflakeGrantRevoke:
+    """Tests for expanded GRANT/REVOKE statements"""
+
+    def test_grant_and_revoke(self):
+        stmts = [
+            "GRANT SELECT ON TABLE mytable TO USER alice;",
+            "GRANT USAGE ON PROCEDURE myproc(VARCHAR) TO APPLICATION ROLE app_role;",
+            "REVOKE SELECT ON VIEW myview FROM SHARE shared_role;",
+        ]
+        for sql in stmts:
+            tree = parse_sql(sql)
+            assert tree is not None
+
+
+class TestSnowflakeShowDescribe:
+    """Tests for additional SHOW/DESCRIBE object kinds"""
+
+    def test_show_describe_variants(self):
+        sqls = [
+            "SHOW FILE FORMATS;",
+            "SHOW SEQUENCES;",
+            "SHOW FUNCTIONS;",
+            "SHOW PROCEDURES;",
+            "SHOW NETWORK POLICIES;",
+            "SHOW STORAGE INTEGRATIONS;",
+            "SHOW NOTIFICATION INTEGRATIONS;",
+            "DESCRIBE FILE FORMAT my_format;",
+            "DESCRIBE NETWORK POLICY np1;",
+        ]
+        for sql in sqls:
+            tree = parse_sql(sql)
+            assert tree is not None
+
+
+class TestSnowflakeLoops:
+    """Tests for LOOP, WHILE, and FOR constructs"""
+
+    def test_loop_while_for(self):
+        sqls = [
+            """
+            BEGIN
+              LET i := 0;
+              WHILE i < 5 DO
+                i := i + 1;
+              END WHILE;
+            END;
+            """,
+            """
+            BEGIN
+              FOR r IN (SELECT 1) DO
+                RETURN r;
+              END FOR;
+            END;
+            """,
+            """
+            BEGIN
+              LOOP
+                RETURN 1;
+              END LOOP;
+            END;
+            """,
+        ]
+        for sql in sqls:
+            tree = parse_sql(sql)
+            assert tree is not None
+
+
+class TestSnowflakeTableFunctions:
+    """Tests for FLATTEN and common table functions"""
+
+    def test_flatten_and_functions(self):
+        sqls = [
+            """
+            SELECT *
+            FROM LATERAL FLATTEN(INPUT => PARSE_JSON(data), PATH => '$', OUTER => TRUE, RECURSIVE => FALSE);
+            """,
+            "SELECT OBJECT_KEYS(v) FROM t;",
+            "SELECT ARRAY_SIZE(a) FROM t;",
+            "SELECT * FROM RESULT_SCAN(LAST_QUERY_ID());",
+        ]
+        for sql in sqls:
+            tree = parse_sql(sql)
+            assert tree is not None


### PR DESCRIPTION
## Summary
- support additional Snowflake data types, loop statements, and expanded object listings
- allow FLATTEN named arguments and broaden privilege handling
- document remaining unsupported Snowflake features

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1f48efe5c832f838a45f839dc3588