### PR TITLE
feat: add notification integration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project was almost entirely built using LLMs.
 ## Features
 
 *   Parses Snowflake SQL syntax using a Lark grammar. Key supported constructs include:
-    *   **DDL**: `CREATE/ALTER/DROP/SHOW/DESCRIBE` for `TABLE`, `VIEW`, `WAREHOUSE`, `TASK`, `STREAM`, `STAGE`, `DATABASE`, `SCHEMA`, `PROCEDURE`, `FUNCTION`, `SEQUENCE`, `RESOURCE MONITOR`, `FILE FORMAT`, `ROLE`, `MASKING POLICY`, `TAG`, `ROW ACCESS POLICY`.
+    *   **DDL**: `CREATE/ALTER/DROP/SHOW/DESCRIBE` for `TABLE`, `VIEW`, `WAREHOUSE`, `TASK`, `STREAM`, `STAGE`, `DATABASE`, `SCHEMA`, `PROCEDURE`, `FUNCTION`, `SEQUENCE`, `RESOURCE MONITOR`, `FILE FORMAT`, `ROLE`, `APPLICATION ROLE`, `DATABASE ROLE`, `ALERT`, `INTEGRATION`, `MASKING POLICY`, `TAG`, `ROW ACCESS POLICY`.
     *   **Advanced DDL**: `CREATE OR REPLACE`, `IF [NOT] EXISTS`, `TRANSIENT` tables, `CLUSTER BY (expr...)`, `DATA_RETENTION_TIME_IN_DAYS`, table `WITH TAG (...)`, column `COMMENT '...'`, `CREATE TABLE AS SELECT` (CTAS), `CLONE` with optional time travel, `CREATE EXTERNAL TABLE` columns, `ALTER TABLE` actions (including `ADD/DROP/RENAME ROW ACCESS POLICY` and `ADD SEARCH OPTIMIZATION`), `CREATE MATERIALIZED VIEW`.
     *   **DML**: `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `INSERT ALL` (multi-table insert), `TRUNCATE`.
     *   **Query**: `SELECT`, `WITH` (CTEs), various `JOIN` types, `WHERE`, `GROUP BY`, `HAVING`, `ORDER BY`, `LIMIT`, window functions (`func() OVER (PARTITION BY ... ORDER BY ...)`), `LATERAL FLATTEN` table functions, `IN (...)` tuple syntax.
@@ -45,7 +45,6 @@ Current implementation covers approximately **80-85%** of the Snowflake SQL spec
 - Advanced Snowflake features:
   - Complete LATERAL FLATTEN and semi-structured data operations
   - Full Cortex Search capabilities
-  - Database and application roles
   - Container Services and job features
 
 - Modern analytics features:
@@ -62,7 +61,6 @@ Current implementation covers approximately **80-85%** of the Snowflake SQL spec
 
 - Data pipeline features:
   - Complete Snowpipe and Snowpipe streaming
-  - Notification integrations
 
 - Newer features (post-2023):
   - Organization accounts

--- a/docs/unsupported_snowflake_syntax.md
+++ b/docs/unsupported_snowflake_syntax.md
@@ -33,5 +33,9 @@ The SQL Analyzer currently parses a large portion of Snowflake SQL, but several 
 - `CREATE SEMANTIC VIEW` and `SEMANTIC_VIEW()` table references
 - New data types `VECTOR`, `GEOGRAPHY`, and `GEOMETRY`
 - Comprehensive window frame definitions with `ROWS`, `RANGE`, or `GROUPS` and `EXCLUDE` options
+- `CREATE/ALTER/DROP/GRANT/REVOKE DATABASE ROLE` (e.g., `CREATE DATABASE ROLE IF NOT EXISTS reporting_role`)
+- `CREATE/ALTER/DROP/GRANT/REVOKE APPLICATION ROLE` (e.g., `CREATE APPLICATION ROLE app_role`)
+- `CREATE/ALTER/DROP/SHOW/DESCRIBE/EXECUTE ALERT` (e.g., `CREATE ALERT my_alert WAREHOUSE = my_wh SCHEDULE = '1 minute' IF EXISTS (SELECT 1) THEN CALL my_proc();`)
+- Notification integrations (e.g., `CREATE NOTIFICATION INTEGRATION email_int TYPE = EMAIL DIRECTION = OUTBOUND ENABLED = TRUE`)
 
 These gaps represent opportunities for future enhancements. Contributions and issue reports are welcome to help extend coverage.

--- a/sample_sql/comprehensive_snowflake.sql
+++ b/sample_sql/comprehensive_snowflake.sql
@@ -117,8 +117,23 @@ CREATE OR REPLACE STAGE my_internal_stage;
 
 GRANT SELECT ON VIEW production.recent_events_v TO ROLE analyst;
 
+-- Database role examples
+CREATE DATABASE ROLE IF NOT EXISTS reporting_role;
+GRANT DATABASE ROLE reporting_role TO ROLE analyst;
+
+-- Application role examples
+CREATE APPLICATION ROLE app_role;
+GRANT APPLICATION ROLE app_role TO ROLE analyst;
+
+-- Alert examples
+CREATE ALERT sales_alert WAREHOUSE = analytics_wh SCHEDULE = '5 minute' IF EXISTS (SELECT 1) THEN CALL process_sales();
+EXECUTE ALERT sales_alert;
+
+-- Notification integration examples
+CREATE NOTIFICATION INTEGRATION email_int TYPE = EMAIL DIRECTION = OUTBOUND ENABLED = TRUE NOTIFICATION_PROVIDER = AWS_SES;
+
 -- Dropping objects (commented out by default)
 -- DROP TABLE IF EXISTS staging.raw_events;
 -- DROP VIEW IF EXISTS production.recent_events_v;
 -- DROP SCHEMA IF EXISTS staging;
--- DROP DATABASE IF EXISTS my_sample_db; 
+-- DROP DATABASE IF EXISTS my_sample_db;

--- a/sql_analyzer/grammar/snowflake.lark
+++ b/sql_analyzer/grammar/snowflake.lark
@@ -161,6 +161,7 @@ ICEBERG: "ICEBERG"i
 PACKAGE: "PACKAGE"i
 INSTALL: "INSTALL"i
 ALERT: "ALERT"i
+ALERTS: "ALERTS"i
 AUTHENTICATION: "AUTHENTICATION"i
 
 // New object types for unsupported features
@@ -214,6 +215,8 @@ INITIALLY_SUSPENDED: "INITIALLY_SUSPENDED"i
 SCHEDULE: "SCHEDULE"i
 SUSPEND: "SUSPEND"i
 RESUME: "RESUME"i
+CONDITION: "CONDITION"i
+ACTION: "ACTION"i
 APPEND_ONLY: "APPEND_ONLY"i
 SHOW_INITIAL_ROWS: "SHOW_INITIAL_ROWS"i
 FILE_FORMAT: "FILE_FORMAT"i
@@ -499,6 +502,11 @@ STORAGE_BLOCKED_LOCATIONS: "STORAGE_BLOCKED_LOCATIONS"i
 NOTIFICATION_PROVIDER: "NOTIFICATION_PROVIDER"i
 GCP_PUBSUB: "GCP_PUBSUB"i
 GCP_PUBSUB_SUBSCRIPTION_NAME: "GCP_PUBSUB_SUBSCRIPTION_NAME"i
+EMAIL: "EMAIL"i
+WEBHOOK: "WEBHOOK"i
+DIRECTION: "DIRECTION"i
+INBOUND: "INBOUND"i
+OUTBOUND: "OUTBOUND"i
 QUEUE: "QUEUE"i
 IMAGE: "IMAGE"i
 REPOSITORIES: "REPOSITORIES"i
@@ -565,7 +573,7 @@ DIRECTORY: "DIRECTORY"i
 ENCRYPTION: "ENCRYPTION"i
 
 // Common Rules
-qualified_name: (IDENTIFIER | PLACEHOLDER | PARAMETER) ( DOT (IDENTIFIER | PLACEHOLDER | PARAMETER) )*
+qualified_name: (IDENTIFIER | DOUBLE_QUOTED_STRING | PLACEHOLDER | PARAMETER) ( DOT (IDENTIFIER | DOUBLE_QUOTED_STRING | PLACEHOLDER | PARAMETER) )*
 
 // Define simple literal types early
 string: SINGLE_QUOTED_STRING | DOUBLE_QUOTED_STRING 
@@ -593,6 +601,15 @@ statement: create_replication_group_stmt
          | copy_into_stmt
          | grant_role_stmt
          | revoke_role_stmt
+         | grant_application_role_stmt
+         | revoke_application_role_stmt
+         | grant_database_role_stmt
+         | revoke_database_role_stmt
+         | show_database_roles_stmt
+         | show_application_roles_stmt
+         | show_alerts_stmt
+         | describe_alert_stmt
+         | execute_alert_stmt
          | enable_search_optimization_stmt
          | disable_search_optimization_stmt
          | alter_search_optimization_stmt
@@ -822,6 +839,8 @@ create_stmt: create_table_stmt
            | create_sequence_stmt
            | create_file_format_stmt
            | create_role_stmt
+           | create_application_role_stmt
+           | create_database_role_stmt
            | create_masking_policy_stmt
            | create_tag_stmt
            | create_row_access_policy_stmt
@@ -836,7 +855,7 @@ create_stmt: create_table_stmt
            | create_materialized_view_stmt
            | create_external_function_stmt
            | create_network_policy_stmt
-           | create_network_rule_stmt
+          | create_network_rule_stmt
            | create_secret_stmt
            | create_security_integration_stmt
            | create_replication_stmt
@@ -1110,6 +1129,8 @@ alter_stmt: alter_table_stmt
           | alter_join_policy_stmt
           | alter_table_set_masking_policy_stmt
           | alter_authentication_policy_stmt
+          | alter_application_role_stmt
+          | alter_database_role_stmt
           | alter_share_stmt
           | alter_integration_stmt
           | alter_external_table_stmt
@@ -1181,6 +1202,8 @@ drop_stmt: drop_share_stmt
         | drop_network_policy_stmt
         | drop_join_policy_stmt
         | drop_iceberg_table_stmt
+        | drop_application_role_stmt
+        | drop_database_role_stmt
         | DROP object_type (IF EXISTS)? qualified_name
         | DROP (IF EXISTS)? ROW ACCESS POLICY qualified_name
         | DROP (IF EXISTS)? MASKING POLICY qualified_name
@@ -1386,7 +1409,31 @@ file_format_option_kv: FIELD_DELIMITER EQ string
 
 FIELD_DELIMITER: "FIELD_DELIMITER"i
 
-create_role_stmt: CREATE (OR REPLACE)? (APPLICATION)? ROLE (IF NOT EXISTS)? qualified_name (MANAGED ACCESS)?
+create_role_stmt: CREATE (OR REPLACE)? ROLE (IF NOT EXISTS)? qualified_name (MANAGED ACCESS)?
+
+create_application_role_stmt: CREATE (OR REPLACE|OR ALTER)? APPLICATION ROLE (IF NOT EXISTS)? qualified_name
+
+alter_application_role_stmt: ALTER APPLICATION ROLE qualified_name (RENAME TO qualified_name)?
+
+drop_application_role_stmt: DROP APPLICATION ROLE (IF EXISTS)? qualified_name
+
+grant_application_role_stmt: GRANT APPLICATION ROLE qualified_name TO ROLE qualified_name
+
+revoke_application_role_stmt: REVOKE APPLICATION ROLE qualified_name FROM ROLE qualified_name
+
+show_application_roles_stmt: SHOW APPLICATION ROLES
+
+create_database_role_stmt: CREATE (OR REPLACE|OR ALTER)? DATABASE ROLE (IF NOT EXISTS)? qualified_name
+
+alter_database_role_stmt: ALTER DATABASE ROLE qualified_name (RENAME TO qualified_name)?
+
+drop_database_role_stmt: DROP DATABASE ROLE (IF EXISTS)? qualified_name
+
+grant_database_role_stmt: GRANT DATABASE ROLE qualified_name TO ROLE qualified_name
+
+revoke_database_role_stmt: REVOKE DATABASE ROLE qualified_name FROM ROLE qualified_name
+
+show_database_roles_stmt: SHOW DATABASE ROLES
 
 ARROW: "->"
 
@@ -1528,9 +1575,14 @@ install_package_stmt: INSTALL PACKAGE qualified_name
 remove_package_stmt: REMOVE PACKAGE qualified_name
 
 // Alert statements
-create_alert_stmt: CREATE ALERT qualified_name
-alter_alert_stmt: ALTER ALERT qualified_name
-drop_alert_stmt: DROP ALERT qualified_name
+create_alert_stmt: CREATE (OR REPLACE)? ALERT qualified_name (clone_clause | alert_definition)
+alter_alert_stmt: ALTER ALERT qualified_name (RESUME | SUSPEND | SET WAREHOUSE EQ qualified_name | SET SCHEDULE EQ string | MODIFY CONDITION expr | MODIFY ACTION call_procedure_stmt)
+drop_alert_stmt: DROP ALERT (IF EXISTS)? qualified_name
+show_alerts_stmt: SHOW ALERTS
+describe_alert_stmt: (DESCRIBE | DESC) ALERT qualified_name
+execute_alert_stmt: EXECUTE ALERT qualified_name
+
+alert_definition: WAREHOUSE EQ qualified_name SCHEDULE EQ string IF expr THEN call_procedure_stmt
 
 // Row access policy enhancements
 alter_row_access_policy_stmt: ALTER ROW ACCESS POLICY qualified_name (SET BODY ARROW expr)?
@@ -1574,12 +1626,13 @@ clone_clause: CLONE qualified_name time_travel_clause?
 
 // INTEGRATION statements
 create_integration_stmt: CREATE (OR REPLACE)? (EXTERNAL ACCESS | STORAGE | NOTIFICATION)? INTEGRATION (IF NOT EXISTS)? qualified_name integration_param*
-alter_integration_stmt: ALTER INTEGRATION qualified_name integration_param*
+alter_integration_stmt: ALTER INTEGRATION qualified_name (SET integration_param+)?
 drop_integration_stmt: DROP INTEGRATION qualified_name
 
 // Parameters for INTEGRATION
-integration_param: TYPE EQ (IDENTIFIER | SINGLE_QUOTED_STRING | EXTERNAL_STAGE | QUEUE)
+integration_param: TYPE EQ (IDENTIFIER | SINGLE_QUOTED_STRING | EXTERNAL_STAGE | QUEUE | EMAIL | WEBHOOK)
                  | ENABLED EQ boolean
+                 | DIRECTION EQ (INBOUND | OUTBOUND)
                  | COMMENT EQ SINGLE_QUOTED_STRING
                  | SECRETS EQ LPAREN SINGLE_QUOTED_STRING (COMMA SINGLE_QUOTED_STRING)* RPAREN
                  | ALLOWED_NETWORK_RULES EQ LPAREN SINGLE_QUOTED_STRING (COMMA SINGLE_QUOTED_STRING)* RPAREN

--- a/tests/test_snowflake_alerts.py
+++ b/tests/test_snowflake_alerts.py
@@ -1,0 +1,59 @@
+import pytest
+from lark import Tree, LarkError
+
+from sql_analyzer.parser.core import parse_sql
+from sql_analyzer.analysis.engine import AnalysisEngine
+
+
+def analyze_sql(sql: str):
+    tree = parse_sql(sql)
+    engine = AnalysisEngine()
+    return engine.analyze(tree)
+
+
+def test_create_alert_with_definition():
+    sql = (
+        "CREATE ALERT my_alert WAREHOUSE = wh SCHEDULE = '1 minute' IF EXISTS (SELECT 1) THEN CALL my_proc();"
+    )
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree)
+    res = analyze_sql(sql)
+    assert res.statement_counts.get("CREATE_ALERT", 0) == 1
+    assert any(o.object_type == "WAREHOUSE" and o.name == "wh" for o in res.objects_found)
+    assert any(o.object_type == "ALERT" and o.action == "SCHEDULE" and o.name == "my_alert" for o in res.objects_found)
+    assert any(o.object_type == "PROCEDURE" and o.action == "CALL" and o.name == "my_proc" for o in res.objects_found)
+
+
+def test_create_alert_clone():
+    sql = "CREATE ALERT new_alert CLONE old_alert;"
+    res = analyze_sql(sql)
+    assert res.statement_counts.get("CREATE_ALERT", 0) == 1
+    assert any(o.object_type == "ALERT" and o.action == "CLONE" and o.name == "old_alert" for o in res.objects_found)
+
+
+def test_execute_and_describe_show_alert():
+    assert isinstance(parse_sql("SHOW ALERTS;"), Tree)
+    assert isinstance(parse_sql("DESC ALERT my_alert;"), Tree)
+    res = analyze_sql("EXECUTE ALERT my_alert;")
+    assert res.statement_counts.get("EXECUTE_ALERT", 0) == 1
+    assert any(o.object_type == "ALERT" and o.action == "EXECUTE_ALERT" and o.name == "my_alert" for o in res.objects_found)
+
+
+def test_alter_alert_set_warehouse():
+    sql = "ALTER ALERT my_alert SET WAREHOUSE = wh2;"
+    res = analyze_sql(sql)
+    assert res.statement_counts.get("ALTER_ALERT", 0) == 1
+    assert any(o.object_type == "WAREHOUSE" and o.name == "wh2" for o in res.objects_found)
+
+
+# Negative tests
+
+def test_invalid_create_alert_missing_schedule():
+    with pytest.raises(LarkError):
+        parse_sql("CREATE ALERT bad_alert WAREHOUSE = wh IF 1=1 THEN CALL proc();")
+
+
+def test_invalid_execute_alert():
+    with pytest.raises(LarkError):
+        parse_sql("EXECUTE ALERT;")
+

--- a/tests/test_snowflake_integrations.py
+++ b/tests/test_snowflake_integrations.py
@@ -1,0 +1,61 @@
+import pytest
+from lark import Tree, LarkError
+
+from sql_analyzer.parser.core import parse_sql
+from sql_analyzer.analysis.engine import AnalysisEngine
+
+
+def analyze_sql(sql: str):
+    tree = parse_sql(sql)
+    engine = AnalysisEngine()
+    return engine.analyze(tree)
+
+
+def test_create_notification_integrations():
+    sql_email = (
+        "CREATE NOTIFICATION INTEGRATION email_int TYPE = EMAIL "
+        "DIRECTION = OUTBOUND ENABLED = TRUE "
+        "NOTIFICATION_PROVIDER = AWS_SES;"
+    )
+    res = analyze_sql(sql_email)
+    assert res.statement_counts.get("CREATE_INTEGRATION", 0) == 1
+    assert any(o.action == "CREATE_INTEGRATION" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "TYPE" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "DIRECTION" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "ENABLED" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "PROVIDER" and o.name == "email_int" for o in res.objects_found)
+
+    sql_queue = (
+        "CREATE NOTIFICATION INTEGRATION queue_int TYPE = QUEUE "
+        "DIRECTION = OUTBOUND ENABLED = FALSE "
+        "NOTIFICATION_PROVIDER = AWS_SQS;"
+    )
+    tree = parse_sql(sql_queue)
+    assert isinstance(tree, Tree)
+
+    sql_webhook = (
+        "CREATE NOTIFICATION INTEGRATION webhook_int TYPE = WEBHOOK "
+        "DIRECTION = INBOUND ENABLED = TRUE "
+        "NOTIFICATION_PROVIDER = CUSTOM;"
+    )
+    tree = parse_sql(sql_webhook)
+    assert isinstance(tree, Tree)
+
+
+def test_alter_notification_integration():
+    sql = (
+        "ALTER INTEGRATION email_int SET ENABLED = FALSE DIRECTION = INBOUND;"
+    )
+    res = analyze_sql(sql)
+    assert res.statement_counts.get("ALTER_INTEGRATION", 0) == 1
+    assert any(o.action == "ALTER_INTEGRATION" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "ENABLED" and o.name == "email_int" for o in res.objects_found)
+    assert any(o.action == "DIRECTION" and o.name == "email_int" for o in res.objects_found)
+
+
+def test_invalid_notification_integration_direction():
+    with pytest.raises(LarkError):
+        parse_sql(
+            "CREATE NOTIFICATION INTEGRATION bad_int TYPE = EMAIL DIRECTION = SIDEWAYS;"
+        )
+

--- a/tests/test_snowflake_roles.py
+++ b/tests/test_snowflake_roles.py
@@ -1,0 +1,169 @@
+import pytest
+from lark import Tree, LarkError
+
+from sql_analyzer.parser.core import parse_sql
+from sql_analyzer.analysis.engine import AnalysisEngine
+
+
+def analyze_sql(sql: str):
+    tree = parse_sql(sql)
+    engine = AnalysisEngine()
+    return engine.analyze(tree)
+
+
+def test_create_database_role_if_not_exists():
+    sql = "CREATE DATABASE ROLE IF NOT EXISTS db_role1;"
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree)
+
+
+def test_create_database_role_quoted():
+    sql = 'CREATE DATABASE ROLE "MyRole";'
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree)
+
+
+def test_create_application_role_if_not_exists():
+    sql = "CREATE APPLICATION ROLE IF NOT EXISTS app_role1;"
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree)
+
+
+def test_create_application_role_quoted():
+    sql = 'CREATE APPLICATION ROLE "AppRole";'
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree)
+
+
+def test_analyze_database_role_actions():
+    res = analyze_sql("CREATE DATABASE ROLE db_role1;")
+    assert res.statement_counts.get("CREATE_DATABASE_ROLE", 0) == 1
+    assert any(o.action == "CREATE_DATABASE_ROLE" and o.name == "db_role1" for o in res.objects_found)
+
+    res = analyze_sql("ALTER DATABASE ROLE db_role1 RENAME TO db_role2;")
+    assert res.statement_counts.get("ALTER_DATABASE_ROLE", 0) == 1
+    assert any(o.action == "ALTER_DATABASE_ROLE" and o.name == "db_role1" for o in res.objects_found)
+
+    res = analyze_sql("DROP DATABASE ROLE db_role2;")
+    assert res.statement_counts.get("DROP_DATABASE_ROLE", 0) == 1
+    assert any(o.action == "DROP_DATABASE_ROLE" and o.name == "db_role2" for o in res.objects_found)
+
+    res = analyze_sql("GRANT DATABASE ROLE db_role2 TO ROLE role1;")
+    assert res.statement_counts.get("GRANT_DATABASE_ROLE", 0) == 1
+    assert any(
+        o.object_type == "DATABASE_ROLE" and o.action == "GRANT_DATABASE_ROLE" and o.name == "db_role2"
+        for o in res.objects_found
+    )
+    assert any(
+        o.object_type == "ROLE" and o.action == "GRANT_DATABASE_ROLE" and o.name == "role1"
+        for o in res.objects_found
+    )
+
+    res = analyze_sql("REVOKE DATABASE ROLE db_role2 FROM ROLE role1;")
+    assert res.statement_counts.get("REVOKE_DATABASE_ROLE", 0) == 1
+    assert any(
+        o.object_type == "DATABASE_ROLE" and o.action == "REVOKE_DATABASE_ROLE" and o.name == "db_role2"
+        for o in res.objects_found
+    )
+    assert any(
+        o.object_type == "ROLE" and o.action == "REVOKE_DATABASE_ROLE" and o.name == "role1"
+        for o in res.objects_found
+    )
+
+    res = analyze_sql("CREATE APPLICATION ROLE app_role1;")
+    assert res.statement_counts.get("CREATE_APPLICATION_ROLE", 0) == 1
+    assert any(o.action == "CREATE_APPLICATION_ROLE" and o.name == "app_role1" for o in res.objects_found)
+
+    res = analyze_sql("ALTER APPLICATION ROLE app_role1 RENAME TO app_role2;")
+    assert res.statement_counts.get("ALTER_APPLICATION_ROLE", 0) == 1
+    assert any(o.action == "ALTER_APPLICATION_ROLE" and o.name == "app_role1" for o in res.objects_found)
+
+    res = analyze_sql("DROP APPLICATION ROLE app_role2;")
+    assert res.statement_counts.get("DROP_APPLICATION_ROLE", 0) == 1
+    assert any(o.action == "DROP_APPLICATION_ROLE" and o.name == "app_role2" for o in res.objects_found)
+
+    res = analyze_sql("GRANT APPLICATION ROLE app_role2 TO ROLE role1;")
+    assert res.statement_counts.get("GRANT_APPLICATION_ROLE", 0) == 1
+    assert any(
+        o.object_type == "APPLICATION_ROLE" and o.action == "GRANT_APPLICATION_ROLE" and o.name == "app_role2"
+        for o in res.objects_found
+    )
+    assert any(
+        o.object_type == "ROLE" and o.action == "GRANT_APPLICATION_ROLE" and o.name == "role1"
+        for o in res.objects_found
+    )
+
+    res = analyze_sql("REVOKE APPLICATION ROLE app_role2 FROM ROLE role1;")
+    assert res.statement_counts.get("REVOKE_APPLICATION_ROLE", 0) == 1
+    assert any(
+        o.object_type == "APPLICATION_ROLE" and o.action == "REVOKE_APPLICATION_ROLE" and o.name == "app_role2"
+        for o in res.objects_found
+    )
+    assert any(
+        o.object_type == "ROLE" and o.action == "REVOKE_APPLICATION_ROLE" and o.name == "role1"
+        for o in res.objects_found
+    )
+
+
+def test_show_database_roles():
+    tree = parse_sql("SHOW DATABASE ROLES;")
+    assert isinstance(tree, Tree)
+
+
+def test_show_application_roles():
+    tree = parse_sql("SHOW APPLICATION ROLES;")
+    assert isinstance(tree, Tree)
+
+
+# Negative tests
+
+
+def test_invalid_create_database_role():
+    with pytest.raises(LarkError):
+        parse_sql("CREATE DATABASE ROLE IF NOT EXISTS;")
+
+
+def test_invalid_alter_database_role():
+    with pytest.raises(LarkError):
+        parse_sql("ALTER DATABASE ROLE;")
+
+
+def test_invalid_drop_database_role():
+    with pytest.raises(LarkError):
+        parse_sql("DROP DATABASE ROLE IF EXISTS;")
+
+
+def test_invalid_grant_database_role():
+    with pytest.raises(LarkError):
+        parse_sql("GRANT DATABASE ROLE db_role TO r1;")
+
+
+def test_invalid_revoke_database_role():
+    with pytest.raises(LarkError):
+        parse_sql("REVOKE DATABASE ROLE db_role FROM r1;")
+
+
+def test_invalid_create_application_role():
+    with pytest.raises(LarkError):
+        parse_sql("CREATE APPLICATION ROLE IF NOT EXISTS;")
+
+
+def test_invalid_alter_application_role():
+    with pytest.raises(LarkError):
+        parse_sql("ALTER APPLICATION ROLE;")
+
+
+def test_invalid_drop_application_role():
+    with pytest.raises(LarkError):
+        parse_sql("DROP APPLICATION ROLE IF EXISTS;")
+
+
+def test_invalid_grant_application_role():
+    with pytest.raises(LarkError):
+        parse_sql("GRANT APPLICATION ROLE app_role TO r1;")
+
+
+def test_invalid_revoke_application_role():
+    with pytest.raises(LarkError):
+        parse_sql("REVOKE APPLICATION ROLE app_role FROM r1;")
+


### PR DESCRIPTION
## Summary
- extend grammar for notification integrations with TYPE, DIRECTION, and provider keywords
- capture integration provider, direction, and enabled flag in visitor
- document notification integration coverage and add samples and tests

## Testing
- `pytest tests/test_snowflake_integrations.py tests/test_snowflake_roles.py tests/test_snowflake_alerts.py`
- `pre-commit run --files README.md docs/unsupported_snowflake_syntax.md sample_sql/comprehensive_snowflake.sql sql_analyzer/grammar/snowflake.lark sql_analyzer/parser/visitor.py tests/test_snowflake_integrations.py` (fails: Executable `sql-analyzer` not found)


------
https://chatgpt.com/codex/tasks/task_e_68a3f5890238832f9293dbbe887ff766