### PR TITLE
Support additional Snowflake syntax

### DIFF
--- a/docs/unsupported_snowflake_syntax.md
+++ b/docs/unsupported_snowflake_syntax.md
@@ -3,8 +3,7 @@
 The SQL Analyzer currently parses a large portion of Snowflake SQL, but several syntax areas remain unsupported or only partially implemented. This document summarizes the main gaps.
 
 ## Core SQL Features
-- Stage queries using `SELECT * EXCLUDE/REPLACE/RENAME`
-- `COPY INTO` options such as `LOAD_MODE`
+- (none currently identified)
 
 ## DDL and Data Types
 - Streamlit apps, dynamic tables, hybrid tables, datasets, and snapshots
@@ -39,6 +38,9 @@ The SQL Analyzer currently parses a large portion of Snowflake SQL, but several 
 - `CREATE/ALTER/DROP/SHOW/DESCRIBE/EXECUTE ALERT` (e.g., `CREATE ALERT my_alert WAREHOUSE = my_wh SCHEDULE = '1 minute' IF EXISTS (SELECT 1) THEN CALL my_proc();`)
 - Notification integrations (e.g., `CREATE NOTIFICATION INTEGRATION email_int TYPE = EMAIL DIRECTION = OUTBOUND ENABLED = TRUE`)
 - `ML.PREDICT` and `ML.TRAIN` function calls
+- Star modifiers `EXCLUDE`, `REPLACE`, and `RENAME` in `SELECT *` lists
+- Enhanced `COPY INTO` options including `LOAD_MODE`
+- `CREATE EXTERNAL TABLE` without column definitions and with `INTEGRATION`/`WITH LOCATION` clauses
 - Apache Iceberg table DDL
 - Snowpark package management (`CREATE/INSTALL/REMOVE PACKAGE`)
 - Row access and masking policies

--- a/docs/unsupported_snowflake_syntax.md
+++ b/docs/unsupported_snowflake_syntax.md
@@ -14,7 +14,6 @@ The SQL Analyzer currently parses a large portion of Snowflake SQL, but several 
 - Creation of user-defined table functions (UDTFs)
 
 ## Ecosystem and Advanced Services
-- Machine learning model DDL and management (`CREATE MODEL`, `ALTER MODEL`, versioning)
 - Advanced function options like `SERVICE` and `CONTEXT_HEADERS`
 
 ## Recently Implemented Features
@@ -38,6 +37,7 @@ The SQL Analyzer currently parses a large portion of Snowflake SQL, but several 
 - `CREATE/ALTER/DROP/SHOW/DESCRIBE/EXECUTE ALERT` (e.g., `CREATE ALERT my_alert WAREHOUSE = my_wh SCHEDULE = '1 minute' IF EXISTS (SELECT 1) THEN CALL my_proc();`)
 - Notification integrations (e.g., `CREATE NOTIFICATION INTEGRATION email_int TYPE = EMAIL DIRECTION = OUTBOUND ENABLED = TRUE`)
 - `ML.PREDICT` and `ML.TRAIN` function calls
+- Machine learning model DDL (`CREATE MODEL`, `ALTER MODEL`, `DROP MODEL`) with versioning
 - Star modifiers `EXCLUDE`, `REPLACE`, and `RENAME` in `SELECT *` lists
 - Enhanced `COPY INTO` options including `LOAD_MODE`
 - `CREATE EXTERNAL TABLE` without column definitions and with `INTEGRATION`/`WITH LOCATION` clauses

--- a/sql_analyzer/grammar/snowflake.lark
+++ b/sql_analyzer/grammar/snowflake.lark
@@ -1575,8 +1575,8 @@ install_package_stmt: INSTALL PACKAGE qualified_name
 remove_package_stmt: REMOVE PACKAGE qualified_name
 
 // Alert statements
-create_alert_stmt: CREATE (OR REPLACE)? ALERT qualified_name (clone_clause | alert_definition)
-alter_alert_stmt: ALTER ALERT qualified_name (RESUME | SUSPEND | SET WAREHOUSE EQ qualified_name | SET SCHEDULE EQ string | MODIFY CONDITION expr | MODIFY ACTION call_procedure_stmt)
+create_alert_stmt: CREATE (OR REPLACE)? ALERT qualified_name (clone_clause | alert_definition)?
+alter_alert_stmt: ALTER ALERT qualified_name (RESUME | SUSPEND | SET WAREHOUSE EQ qualified_name | SET SCHEDULE EQ string | MODIFY CONDITION expr | MODIFY ACTION call_procedure_stmt)?
 drop_alert_stmt: DROP ALERT (IF EXISTS)? qualified_name
 show_alerts_stmt: SHOW ALERTS
 describe_alert_stmt: (DESCRIBE | DESC) ALERT qualified_name
@@ -1626,7 +1626,7 @@ clone_clause: CLONE qualified_name time_travel_clause?
 
 // INTEGRATION statements
 create_integration_stmt: CREATE (OR REPLACE)? (EXTERNAL ACCESS | STORAGE | NOTIFICATION)? INTEGRATION (IF NOT EXISTS)? qualified_name integration_param*
-alter_integration_stmt: ALTER INTEGRATION qualified_name (SET integration_param+)?
+alter_integration_stmt: ALTER INTEGRATION qualified_name (SET? integration_param+)?
 drop_integration_stmt: DROP INTEGRATION qualified_name
 
 // Parameters for INTEGRATION
@@ -1646,7 +1646,11 @@ integration_param: TYPE EQ (IDENTIFIER | SINGLE_QUOTED_STRING | EXTERNAL_STAGE |
                  | GCP_PUBSUB_SUBSCRIPTION_NAME EQ SINGLE_QUOTED_STRING
 
 // External Table statements
-create_external_table_stmt: CREATE (OR REPLACE)? EXTERNAL TABLE (IF NOT EXISTS)? qualified_name LPAREN ext_column_def (COMMA ext_column_def)* RPAREN external_table_options
+// Column definitions are optional for CREATE EXTERNAL TABLE so that minimal
+// forms like `CREATE EXTERNAL TABLE t WITH LOCATION = @stage` are accepted.
+// This also enables examples that specify options such as INTEGRATION without
+// declaring columns.
+create_external_table_stmt: CREATE (OR REPLACE)? EXTERNAL TABLE (IF NOT EXISTS)? qualified_name (LPAREN ext_column_def (COMMA ext_column_def)* RPAREN)? external_table_options
 alter_external_table_stmt: ALTER EXTERNAL TABLE qualified_name (REFRESH)?
 drop_external_table_stmt: DROP EXTERNAL TABLE qualified_name
 

--- a/sql_analyzer/grammar/snowflake.lark
+++ b/sql_analyzer/grammar/snowflake.lark
@@ -675,7 +675,9 @@ statement: create_replication_group_stmt
          | create_hybrid_table_stmt
          | create_dataset_stmt
          | alter_dataset_stmt
+         | create_model_stmt
          | alter_model_stmt
+         | drop_model_stmt
          | drop_snapshot_stmt
          | create_external_volume_stmt
          | drop_external_volume_stmt
@@ -1812,7 +1814,12 @@ create_dataset_stmt: CREATE (OR REPLACE)? DATASET qualified_name
 alter_dataset_stmt: ALTER DATASET qualified_name DROP VERSION SINGLE_QUOTED_STRING
 
 // ========== MODEL STATEMENTS ==========
+create_model_stmt: CREATE (OR REPLACE)? MODEL qualified_name create_model_clause?
 alter_model_stmt: ALTER MODEL qualified_name alter_model_action
+drop_model_stmt: DROP MODEL qualified_name
+
+create_model_clause: WITH VERSION IDENTIFIER from_model_clause?
+from_model_clause: FROM MODEL qualified_name (VERSION IDENTIFIER)?
 
 alter_model_action: DROP VERSION IDENTIFIER
                   | SET COMMENT EQ SINGLE_QUOTED_STRING

--- a/sql_analyzer/parser/visitor.py
+++ b/sql_analyzer/parser/visitor.py
@@ -864,7 +864,7 @@ class SQLVisitor(Visitor[Token]): # Inherit from Visitor[Token] for better type 
                         obj_type_tokens.append(type_token.type)
                 
                 # Check for single token types first
-                if len(obj_type_tokens) == 1 and obj_type_tokens[0] in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE'):
+                if len(obj_type_tokens) == 1 and obj_type_tokens[0] in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE', 'MODEL'):
                     obj_type = obj_type_tokens[0]
                     logger.debug(f"Found object type token: {obj_type}")
                     break
@@ -894,7 +894,7 @@ class SQLVisitor(Visitor[Token]): # Inherit from Visitor[Token] for better type 
         if not obj_type:
             # Check for direct object type tokens like TABLE, VIEW, etc. as direct children
             for i, child in enumerate(children):
-                if isinstance(child, Token) and child.type in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE', 'ROW'):
+                if isinstance(child, Token) and child.type in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE', 'ROW', 'MODEL'):
                     obj_type = child.type
                     logger.debug(f"Found direct object type token: {obj_type}")
                     break
@@ -913,7 +913,7 @@ class SQLVisitor(Visitor[Token]): # Inherit from Visitor[Token] for better type 
                             obj_type_tokens.append(child.type)
                             
                             # Try to determine the type based on collected tokens
-                            if child.type in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE'):
+                            if child.type in ('TABLE', 'VIEW', 'TASK', 'WAREHOUSE', 'DATABASE', 'SCHEMA', 'FUNCTION', 'SHARE', 'INTEGRATION', 'PIPE', 'MODEL'):
                                 if len(obj_type_tokens) == 1:
                                     # Simple case: DROP followed by single type
                                     obj_type = child.type
@@ -978,6 +978,8 @@ class SQLVisitor(Visitor[Token]): # Inherit from Visitor[Token] for better type 
                 action = "DROP_INTEGRATION"
             elif obj_type == "PIPE":
                 action = "DROP_PIPE"
+            elif obj_type == "MODEL":
+                action = "DROP_MODEL"
             else:
                 action = "DROP"
                 
@@ -1903,6 +1905,9 @@ class SQLVisitor(Visitor[Token]): # Inherit from Visitor[Token] for better type 
         ('create_alert_stmt', 'ALERT', 'CREATE_ALERT', 'Create Alert'),
         ('alter_alert_stmt', 'ALERT', 'ALTER_ALERT', 'Alter Alert'),
         ('drop_alert_stmt', 'ALERT', 'DROP_ALERT', 'Drop Alert'),
+        ('create_model_stmt', 'MODEL', 'CREATE_MODEL', 'Create Model'),
+        ('alter_model_stmt', 'MODEL', 'ALTER_MODEL', 'Alter Model'),
+        ('drop_model_stmt', 'MODEL', 'DROP_MODEL', 'Drop Model'),
         ('create_iceberg_table_stmt', 'ICEBERG_TABLE', 'CREATE_ICEBERG_TABLE', 'Create Iceberg Table'),
         ('alter_iceberg_table_stmt', 'ICEBERG_TABLE', 'ALTER_ICEBERG_TABLE', 'Alter Iceberg Table'),
         ('drop_iceberg_table_stmt', 'ICEBERG_TABLE', 'DROP_ICEBERG_TABLE', 'Drop Iceberg Table'),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -539,6 +539,38 @@ def test_parse_stage_fileformat_copyinto_invalid_fixture():
     with pytest.raises(LarkError):
         parse_sql(sql)
 
+
+def test_parse_copy_into_with_load_mode():
+    sql = (
+        "COPY INTO customer_iceberg_ingest "
+        "FROM @my_parquet_stage "
+        "FILE_FORMAT = 'my_parquet_format' "
+        "LOAD_MODE = ADD_FILES_COPY PURGE = TRUE "
+        "MATCH_BY_COLUMN_NAME = CASE_SENSITIVE;"
+    )
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree), "COPY INTO with LOAD_MODE should parse"
+
+
+def test_parse_select_star_modifiers():
+    sql = (
+        "SELECT * EXCLUDE (sensitive_col) "
+        "REPLACE (UPPER(name) AS name) "
+        "RENAME (old_col AS new_col) FROM my_table;"
+    )
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree), "SELECT * with EXCLUDE/REPLACE/RENAME should parse"
+
+
+def test_create_external_table_without_columns():
+    sql = (
+        "CREATE OR REPLACE EXTERNAL TABLE ext_table "
+        "INTEGRATION = 'MY_NOTIFICATION_INT' WITH LOCATION = @mystage/path1/ "
+        "FILE_FORMAT = (TYPE = JSON);"
+    )
+    tree = parse_sql(sql)
+    assert isinstance(tree, Tree), "CREATE EXTERNAL TABLE without columns should parse"
+
 def test_parse_drop_task():
     """Test parsing DROP TASK statement specifically."""
     sql = "DROP TASK IF EXISTS my_task;"


### PR DESCRIPTION
## Summary
- allow optional column list and integration/location options in `CREATE EXTERNAL TABLE`
- relax `CREATE ALERT`/`ALTER ALERT` syntax and simplify `ALTER INTEGRATION`
- add tests for star modifiers, COPY INTO load modes and column-less external tables; update unsupported syntax docs

## Testing
- `pytest tests/test_parser.py::test_parse_copy_into_with_load_mode tests/test_parser.py::test_parse_select_star_modifiers tests/test_parser.py::test_create_external_table_without_columns tests/test_snowflake_additional_features.py::test_parse_create_alert tests/test_snowflake_additional_features.py::test_parse_alter_alert tests/test_snowflake_additional_features.py::test_analyze_alert_statements tests/test_snowflake_full_core_features.py::test_integration_alter -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9a267f1bc832fb15194bd0e0b92b2

https://chatgpt.com/s/cd_68b9b807dc948191b4a9d7b51412f09e